### PR TITLE
State that only utf-8 is supported

### DIFF
--- a/templates/peer_review/userAdmin.html
+++ b/templates/peer_review/userAdmin.html
@@ -137,6 +137,8 @@
                                     'Mr, JF, John, Bool, johnbool@example.com, 123456789, john';
                                 $('#csv_example').text(str);
                             </script>
+
+                            The CSV file needs to be encoded in utf-8.
                         </div>
                         <form class="col-md-6" action="{% url 'submitCSV' %}" method="post"
                               enctype="multipart/form-data">


### PR DESCRIPTION
Fixes #190 

### Added
- Note stating that only utf-8 is supported for CSV encoding

### Screenshots
![uni](https://user-images.githubusercontent.com/5778739/38030177-2f9d28ce-3298-11e8-8107-8179a0040e40.png)
